### PR TITLE
rename util functions for union types

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "rami3l/js-ffi",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "readme": "README.md",
   "repository": "",
   "license": "Apache-2.0",

--- a/src/js/js.mbti
+++ b/src/js/js.mbti
@@ -63,100 +63,100 @@ impl Symbol {
 
 type Union2[_, _]
 impl Union2 {
-  from1[A : Cast, B](A) -> Self[A, B]
-  from2[A, B : Cast](B) -> Self[A, B]
-  to1[A : Cast, B](Self[A, B]) -> A?
-  to2[A, B : Cast](Self[A, B]) -> B?
+  from0[A : Cast, B](A) -> Self[A, B]
+  from1[A, B : Cast](B) -> Self[A, B]
+  to0[A : Cast, B](Self[A, B]) -> A?
+  to1[A, B : Cast](Self[A, B]) -> B?
 }
 
 type Union3[_, _, _]
 impl Union3 {
-  from1[A : Cast, B, C](A) -> Self[A, B, C]
-  from2[A, B : Cast, C](B) -> Self[A, B, C]
-  from3[A, B, C : Cast](C) -> Self[A, B, C]
-  to1[A : Cast, B, C](Self[A, B, C]) -> A?
-  to2[A, B : Cast, C](Self[A, B, C]) -> B?
-  to3[A, B, C : Cast](Self[A, B, C]) -> C?
+  from0[A : Cast, B, C](A) -> Self[A, B, C]
+  from1[A, B : Cast, C](B) -> Self[A, B, C]
+  from2[A, B, C : Cast](C) -> Self[A, B, C]
+  to0[A : Cast, B, C](Self[A, B, C]) -> A?
+  to1[A, B : Cast, C](Self[A, B, C]) -> B?
+  to2[A, B, C : Cast](Self[A, B, C]) -> C?
 }
 
 type Union4[_, _, _, _]
 impl Union4 {
-  from1[A : Cast, B, C, D](A) -> Self[A, B, C, D]
-  from2[A, B : Cast, C, D](B) -> Self[A, B, C, D]
-  from3[A, B, C : Cast, D](C) -> Self[A, B, C, D]
-  from4[A, B, C, D : Cast](D) -> Self[A, B, C, D]
-  to1[A : Cast, B, C, D](Self[A, B, C, D]) -> A?
-  to2[A, B : Cast, C, D](Self[A, B, C, D]) -> B?
-  to3[A, B, C : Cast, D](Self[A, B, C, D]) -> C?
-  to4[A, B, C, D : Cast](Self[A, B, C, D]) -> D?
+  from0[A : Cast, B, C, D](A) -> Self[A, B, C, D]
+  from1[A, B : Cast, C, D](B) -> Self[A, B, C, D]
+  from2[A, B, C : Cast, D](C) -> Self[A, B, C, D]
+  from3[A, B, C, D : Cast](D) -> Self[A, B, C, D]
+  to0[A : Cast, B, C, D](Self[A, B, C, D]) -> A?
+  to1[A, B : Cast, C, D](Self[A, B, C, D]) -> B?
+  to2[A, B, C : Cast, D](Self[A, B, C, D]) -> C?
+  to3[A, B, C, D : Cast](Self[A, B, C, D]) -> D?
 }
 
 type Union5[_, _, _, _, _]
 impl Union5 {
-  from1[A : Cast, B, C, D, E](A) -> Self[A, B, C, D, E]
-  from2[A, B : Cast, C, D, E](B) -> Self[A, B, C, D, E]
-  from3[A, B, C : Cast, D, E](C) -> Self[A, B, C, D, E]
-  from4[A, B, C, D : Cast, E](D) -> Self[A, B, C, D, E]
-  from5[A, B, C, D, E : Cast](E) -> Self[A, B, C, D, E]
-  to1[A : Cast, B, C, D, E](Self[A, B, C, D, E]) -> A?
-  to2[A, B : Cast, C, D, E](Self[A, B, C, D, E]) -> B?
-  to3[A, B, C : Cast, D, E](Self[A, B, C, D, E]) -> C?
-  to4[A, B, C, D : Cast, E](Self[A, B, C, D, E]) -> D?
-  to5[A, B, C, D, E : Cast](Self[A, B, C, D, E]) -> E?
+  from0[A : Cast, B, C, D, E](A) -> Self[A, B, C, D, E]
+  from1[A, B : Cast, C, D, E](B) -> Self[A, B, C, D, E]
+  from2[A, B, C : Cast, D, E](C) -> Self[A, B, C, D, E]
+  from3[A, B, C, D : Cast, E](D) -> Self[A, B, C, D, E]
+  from4[A, B, C, D, E : Cast](E) -> Self[A, B, C, D, E]
+  to0[A : Cast, B, C, D, E](Self[A, B, C, D, E]) -> A?
+  to1[A, B : Cast, C, D, E](Self[A, B, C, D, E]) -> B?
+  to2[A, B, C : Cast, D, E](Self[A, B, C, D, E]) -> C?
+  to3[A, B, C, D : Cast, E](Self[A, B, C, D, E]) -> D?
+  to4[A, B, C, D, E : Cast](Self[A, B, C, D, E]) -> E?
 }
 
 type Union6[_, _, _, _, _, _]
 impl Union6 {
-  from1[A : Cast, B, C, D, E, F](A) -> Self[A, B, C, D, E, F]
-  from2[A, B : Cast, C, D, E, F](B) -> Self[A, B, C, D, E, F]
-  from3[A, B, C : Cast, D, E, F](C) -> Self[A, B, C, D, E, F]
-  from4[A, B, C, D : Cast, E, F](D) -> Self[A, B, C, D, E, F]
-  from5[A, B, C, D, E : Cast, F](E) -> Self[A, B, C, D, E, F]
-  from6[A, B, C, D, E, F : Cast](F) -> Self[A, B, C, D, E, F]
-  to1[A : Cast, B, C, D, E, F](Self[A, B, C, D, E, F]) -> A?
-  to2[A, B : Cast, C, D, E, F](Self[A, B, C, D, E, F]) -> B?
-  to3[A, B, C : Cast, D, E, F](Self[A, B, C, D, E, F]) -> C?
-  to4[A, B, C, D : Cast, E, F](Self[A, B, C, D, E, F]) -> D?
-  to5[A, B, C, D, E : Cast, F](Self[A, B, C, D, E, F]) -> E?
-  to6[A, B, C, D, E, F : Cast](Self[A, B, C, D, E, F]) -> F?
+  from0[A : Cast, B, C, D, E, F](A) -> Self[A, B, C, D, E, F]
+  from1[A, B : Cast, C, D, E, F](B) -> Self[A, B, C, D, E, F]
+  from2[A, B, C : Cast, D, E, F](C) -> Self[A, B, C, D, E, F]
+  from3[A, B, C, D : Cast, E, F](D) -> Self[A, B, C, D, E, F]
+  from4[A, B, C, D, E : Cast, F](E) -> Self[A, B, C, D, E, F]
+  from5[A, B, C, D, E, F : Cast](F) -> Self[A, B, C, D, E, F]
+  to0[A : Cast, B, C, D, E, F](Self[A, B, C, D, E, F]) -> A?
+  to1[A, B : Cast, C, D, E, F](Self[A, B, C, D, E, F]) -> B?
+  to2[A, B, C : Cast, D, E, F](Self[A, B, C, D, E, F]) -> C?
+  to3[A, B, C, D : Cast, E, F](Self[A, B, C, D, E, F]) -> D?
+  to4[A, B, C, D, E : Cast, F](Self[A, B, C, D, E, F]) -> E?
+  to5[A, B, C, D, E, F : Cast](Self[A, B, C, D, E, F]) -> F?
 }
 
 type Union7[_, _, _, _, _, _, _]
 impl Union7 {
-  from1[A : Cast, B, C, D, E, F, G](A) -> Self[A, B, C, D, E, F, G]
-  from2[A, B : Cast, C, D, E, F, G](B) -> Self[A, B, C, D, E, F, G]
-  from3[A, B, C : Cast, D, E, F, G](C) -> Self[A, B, C, D, E, F, G]
-  from4[A, B, C, D : Cast, E, F, G](D) -> Self[A, B, C, D, E, F, G]
-  from5[A, B, C, D, E : Cast, F, G](E) -> Self[A, B, C, D, E, F, G]
-  from6[A, B, C, D, E, F : Cast, G](F) -> Self[A, B, C, D, E, F, G]
-  from7[A, B, C, D, E, F, G : Cast](G) -> Self[A, B, C, D, E, F, G]
-  to1[A : Cast, B, C, D, E, F, G](Self[A, B, C, D, E, F, G]) -> A?
-  to2[A, B : Cast, C, D, E, F, G](Self[A, B, C, D, E, F, G]) -> B?
-  to3[A, B, C : Cast, D, E, F, G](Self[A, B, C, D, E, F, G]) -> C?
-  to4[A, B, C, D : Cast, E, F, G](Self[A, B, C, D, E, F, G]) -> D?
-  to5[A, B, C, D, E : Cast, F, G](Self[A, B, C, D, E, F, G]) -> E?
-  to6[A, B, C, D, E, F : Cast, G](Self[A, B, C, D, E, F, G]) -> F?
-  to7[A, B, C, D, E, F, G : Cast](Self[A, B, C, D, E, F, G]) -> G?
+  from0[A : Cast, B, C, D, E, F, G](A) -> Self[A, B, C, D, E, F, G]
+  from1[A, B : Cast, C, D, E, F, G](B) -> Self[A, B, C, D, E, F, G]
+  from2[A, B, C : Cast, D, E, F, G](C) -> Self[A, B, C, D, E, F, G]
+  from3[A, B, C, D : Cast, E, F, G](D) -> Self[A, B, C, D, E, F, G]
+  from4[A, B, C, D, E : Cast, F, G](E) -> Self[A, B, C, D, E, F, G]
+  from5[A, B, C, D, E, F : Cast, G](F) -> Self[A, B, C, D, E, F, G]
+  from6[A, B, C, D, E, F, G : Cast](G) -> Self[A, B, C, D, E, F, G]
+  to0[A : Cast, B, C, D, E, F, G](Self[A, B, C, D, E, F, G]) -> A?
+  to1[A, B : Cast, C, D, E, F, G](Self[A, B, C, D, E, F, G]) -> B?
+  to2[A, B, C : Cast, D, E, F, G](Self[A, B, C, D, E, F, G]) -> C?
+  to3[A, B, C, D : Cast, E, F, G](Self[A, B, C, D, E, F, G]) -> D?
+  to4[A, B, C, D, E : Cast, F, G](Self[A, B, C, D, E, F, G]) -> E?
+  to5[A, B, C, D, E, F : Cast, G](Self[A, B, C, D, E, F, G]) -> F?
+  to6[A, B, C, D, E, F, G : Cast](Self[A, B, C, D, E, F, G]) -> G?
 }
 
 type Union8[_, _, _, _, _, _, _, _]
 impl Union8 {
-  from1[A : Cast, B, C, D, E, F, G, H](A) -> Self[A, B, C, D, E, F, G, H]
-  from2[A, B : Cast, C, D, E, F, G, H](B) -> Self[A, B, C, D, E, F, G, H]
-  from3[A, B, C : Cast, D, E, F, G, H](C) -> Self[A, B, C, D, E, F, G, H]
-  from4[A, B, C, D : Cast, E, F, G, H](D) -> Self[A, B, C, D, E, F, G, H]
-  from5[A, B, C, D, E : Cast, F, G, H](E) -> Self[A, B, C, D, E, F, G, H]
-  from6[A, B, C, D, E, F : Cast, G, H](F) -> Self[A, B, C, D, E, F, G, H]
-  from7[A, B, C, D, E, F, G : Cast, H](G) -> Self[A, B, C, D, E, F, G, H]
-  from8[A, B, C, D, E, F, G, H : Cast](H) -> Self[A, B, C, D, E, F, G, H]
-  to1[A : Cast, B, C, D, E, F, G, H](Self[A, B, C, D, E, F, G, H]) -> A?
-  to2[A, B : Cast, C, D, E, F, G, H](Self[A, B, C, D, E, F, G, H]) -> B?
-  to3[A, B, C : Cast, D, E, F, G, H](Self[A, B, C, D, E, F, G, H]) -> C?
-  to4[A, B, C, D : Cast, E, F, G, H](Self[A, B, C, D, E, F, G, H]) -> D?
-  to5[A, B, C, D, E : Cast, F, G, H](Self[A, B, C, D, E, F, G, H]) -> E?
-  to6[A, B, C, D, E, F : Cast, G, H](Self[A, B, C, D, E, F, G, H]) -> F?
-  to7[A, B, C, D, E, F, G : Cast, H](Self[A, B, C, D, E, F, G, H]) -> G?
-  to8[A, B, C, D, E, F, G, H : Cast](Self[A, B, C, D, E, F, G, H]) -> H?
+  from0[A : Cast, B, C, D, E, F, G, H](A) -> Self[A, B, C, D, E, F, G, H]
+  from1[A, B : Cast, C, D, E, F, G, H](B) -> Self[A, B, C, D, E, F, G, H]
+  from2[A, B, C : Cast, D, E, F, G, H](C) -> Self[A, B, C, D, E, F, G, H]
+  from3[A, B, C, D : Cast, E, F, G, H](D) -> Self[A, B, C, D, E, F, G, H]
+  from4[A, B, C, D, E : Cast, F, G, H](E) -> Self[A, B, C, D, E, F, G, H]
+  from5[A, B, C, D, E, F : Cast, G, H](F) -> Self[A, B, C, D, E, F, G, H]
+  from6[A, B, C, D, E, F, G : Cast, H](G) -> Self[A, B, C, D, E, F, G, H]
+  from7[A, B, C, D, E, F, G, H : Cast](H) -> Self[A, B, C, D, E, F, G, H]
+  to0[A : Cast, B, C, D, E, F, G, H](Self[A, B, C, D, E, F, G, H]) -> A?
+  to1[A, B : Cast, C, D, E, F, G, H](Self[A, B, C, D, E, F, G, H]) -> B?
+  to2[A, B, C : Cast, D, E, F, G, H](Self[A, B, C, D, E, F, G, H]) -> C?
+  to3[A, B, C, D : Cast, E, F, G, H](Self[A, B, C, D, E, F, G, H]) -> D?
+  to4[A, B, C, D, E : Cast, F, G, H](Self[A, B, C, D, E, F, G, H]) -> E?
+  to5[A, B, C, D, E, F : Cast, G, H](Self[A, B, C, D, E, F, G, H]) -> F?
+  to6[A, B, C, D, E, F, G : Cast, H](Self[A, B, C, D, E, F, G, H]) -> G?
+  to7[A, B, C, D, E, F, G, H : Cast](Self[A, B, C, D, E, F, G, H]) -> H?
 }
 
 pub type Value

--- a/src/js/union.mbt
+++ b/src/js/union.mbt
@@ -2,22 +2,22 @@
 type Union2[_, _]
 
 ///|
-pub fn Union2::to1[A : Cast, B](self : Union2[A, B]) -> A? {
+pub fn Union2::to0[A : Cast, B](self : Union2[A, B]) -> A? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union2::to2[A, B : Cast](self : Union2[A, B]) -> B? {
+pub fn Union2::to1[A, B : Cast](self : Union2[A, B]) -> B? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union2::from1[A : Cast, B](value : A) -> Union2[A, B] {
+pub fn Union2::from0[A : Cast, B](value : A) -> Union2[A, B] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union2::from2[A, B : Cast](value : B) -> Union2[A, B] {
+pub fn Union2::from1[A, B : Cast](value : B) -> Union2[A, B] {
   Cast::from(value).cast()
 }
 
@@ -25,32 +25,32 @@ pub fn Union2::from2[A, B : Cast](value : B) -> Union2[A, B] {
 type Union3[_, _, _]
 
 ///|
-pub fn Union3::to1[A : Cast, B, C](self : Union3[A, B, C]) -> A? {
+pub fn Union3::to0[A : Cast, B, C](self : Union3[A, B, C]) -> A? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union3::to2[A, B : Cast, C](self : Union3[A, B, C]) -> B? {
+pub fn Union3::to1[A, B : Cast, C](self : Union3[A, B, C]) -> B? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union3::to3[A, B, C : Cast](self : Union3[A, B, C]) -> C? {
+pub fn Union3::to2[A, B, C : Cast](self : Union3[A, B, C]) -> C? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union3::from1[A : Cast, B, C](value : A) -> Union3[A, B, C] {
+pub fn Union3::from0[A : Cast, B, C](value : A) -> Union3[A, B, C] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union3::from2[A, B : Cast, C](value : B) -> Union3[A, B, C] {
+pub fn Union3::from1[A, B : Cast, C](value : B) -> Union3[A, B, C] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union3::from3[A, B, C : Cast](value : C) -> Union3[A, B, C] {
+pub fn Union3::from2[A, B, C : Cast](value : C) -> Union3[A, B, C] {
   Cast::from(value).cast()
 }
 
@@ -58,42 +58,42 @@ pub fn Union3::from3[A, B, C : Cast](value : C) -> Union3[A, B, C] {
 type Union4[_, _, _, _]
 
 ///|
-pub fn Union4::to1[A : Cast, B, C, D](self : Union4[A, B, C, D]) -> A? {
+pub fn Union4::to0[A : Cast, B, C, D](self : Union4[A, B, C, D]) -> A? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union4::to2[A, B : Cast, C, D](self : Union4[A, B, C, D]) -> B? {
+pub fn Union4::to1[A, B : Cast, C, D](self : Union4[A, B, C, D]) -> B? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union4::to3[A, B, C : Cast, D](self : Union4[A, B, C, D]) -> C? {
+pub fn Union4::to2[A, B, C : Cast, D](self : Union4[A, B, C, D]) -> C? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union4::to4[A, B, C, D : Cast](self : Union4[A, B, C, D]) -> D? {
+pub fn Union4::to3[A, B, C, D : Cast](self : Union4[A, B, C, D]) -> D? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union4::from1[A : Cast, B, C, D](value : A) -> Union4[A, B, C, D] {
+pub fn Union4::from0[A : Cast, B, C, D](value : A) -> Union4[A, B, C, D] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union4::from2[A, B : Cast, C, D](value : B) -> Union4[A, B, C, D] {
+pub fn Union4::from1[A, B : Cast, C, D](value : B) -> Union4[A, B, C, D] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union4::from3[A, B, C : Cast, D](value : C) -> Union4[A, B, C, D] {
+pub fn Union4::from2[A, B, C : Cast, D](value : C) -> Union4[A, B, C, D] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union4::from4[A, B, C, D : Cast](value : D) -> Union4[A, B, C, D] {
+pub fn Union4::from3[A, B, C, D : Cast](value : D) -> Union4[A, B, C, D] {
   Cast::from(value).cast()
 }
 
@@ -101,52 +101,52 @@ pub fn Union4::from4[A, B, C, D : Cast](value : D) -> Union4[A, B, C, D] {
 type Union5[_, _, _, _, _]
 
 ///|
-pub fn Union5::to1[A : Cast, B, C, D, E](self : Union5[A, B, C, D, E]) -> A? {
+pub fn Union5::to0[A : Cast, B, C, D, E](self : Union5[A, B, C, D, E]) -> A? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union5::to2[A, B : Cast, C, D, E](self : Union5[A, B, C, D, E]) -> B? {
+pub fn Union5::to1[A, B : Cast, C, D, E](self : Union5[A, B, C, D, E]) -> B? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union5::to3[A, B, C : Cast, D, E](self : Union5[A, B, C, D, E]) -> C? {
+pub fn Union5::to2[A, B, C : Cast, D, E](self : Union5[A, B, C, D, E]) -> C? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union5::to4[A, B, C, D : Cast, E](self : Union5[A, B, C, D, E]) -> D? {
+pub fn Union5::to3[A, B, C, D : Cast, E](self : Union5[A, B, C, D, E]) -> D? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union5::to5[A, B, C, D, E : Cast](self : Union5[A, B, C, D, E]) -> E? {
+pub fn Union5::to4[A, B, C, D, E : Cast](self : Union5[A, B, C, D, E]) -> E? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union5::from1[A : Cast, B, C, D, E](value : A) -> Union5[A, B, C, D, E] {
+pub fn Union5::from0[A : Cast, B, C, D, E](value : A) -> Union5[A, B, C, D, E] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union5::from2[A, B : Cast, C, D, E](value : B) -> Union5[A, B, C, D, E] {
+pub fn Union5::from1[A, B : Cast, C, D, E](value : B) -> Union5[A, B, C, D, E] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union5::from3[A, B, C : Cast, D, E](value : C) -> Union5[A, B, C, D, E] {
+pub fn Union5::from2[A, B, C : Cast, D, E](value : C) -> Union5[A, B, C, D, E] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union5::from4[A, B, C, D : Cast, E](value : D) -> Union5[A, B, C, D, E] {
+pub fn Union5::from3[A, B, C, D : Cast, E](value : D) -> Union5[A, B, C, D, E] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union5::from5[A, B, C, D, E : Cast](value : E) -> Union5[A, B, C, D, E] {
+pub fn Union5::from4[A, B, C, D, E : Cast](value : E) -> Union5[A, B, C, D, E] {
   Cast::from(value).cast()
 }
 
@@ -154,84 +154,84 @@ pub fn Union5::from5[A, B, C, D, E : Cast](value : E) -> Union5[A, B, C, D, E] {
 type Union6[_, _, _, _, _, _]
 
 ///|
-pub fn Union6::to1[A : Cast, B, C, D, E, F](
+pub fn Union6::to0[A : Cast, B, C, D, E, F](
   self : Union6[A, B, C, D, E, F]
 ) -> A? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union6::to2[A, B : Cast, C, D, E, F](
+pub fn Union6::to1[A, B : Cast, C, D, E, F](
   self : Union6[A, B, C, D, E, F]
 ) -> B? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union6::to3[A, B, C : Cast, D, E, F](
+pub fn Union6::to2[A, B, C : Cast, D, E, F](
   self : Union6[A, B, C, D, E, F]
 ) -> C? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union6::to4[A, B, C, D : Cast, E, F](
+pub fn Union6::to3[A, B, C, D : Cast, E, F](
   self : Union6[A, B, C, D, E, F]
 ) -> D? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union6::to5[A, B, C, D, E : Cast, F](
+pub fn Union6::to4[A, B, C, D, E : Cast, F](
   self : Union6[A, B, C, D, E, F]
 ) -> E? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union6::to6[A, B, C, D, E, F : Cast](
+pub fn Union6::to5[A, B, C, D, E, F : Cast](
   self : Union6[A, B, C, D, E, F]
 ) -> F? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union6::from1[A : Cast, B, C, D, E, F](
+pub fn Union6::from0[A : Cast, B, C, D, E, F](
   value : A
 ) -> Union6[A, B, C, D, E, F] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union6::from2[A, B : Cast, C, D, E, F](
+pub fn Union6::from1[A, B : Cast, C, D, E, F](
   value : B
 ) -> Union6[A, B, C, D, E, F] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union6::from3[A, B, C : Cast, D, E, F](
+pub fn Union6::from2[A, B, C : Cast, D, E, F](
   value : C
 ) -> Union6[A, B, C, D, E, F] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union6::from4[A, B, C, D : Cast, E, F](
+pub fn Union6::from3[A, B, C, D : Cast, E, F](
   value : D
 ) -> Union6[A, B, C, D, E, F] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union6::from5[A, B, C, D, E : Cast, F](
+pub fn Union6::from4[A, B, C, D, E : Cast, F](
   value : E
 ) -> Union6[A, B, C, D, E, F] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union6::from6[A, B, C, D, E, F : Cast](
+pub fn Union6::from5[A, B, C, D, E, F : Cast](
   value : F
 ) -> Union6[A, B, C, D, E, F] {
   Cast::from(value).cast()
@@ -241,98 +241,98 @@ pub fn Union6::from6[A, B, C, D, E, F : Cast](
 type Union7[_, _, _, _, _, _, _]
 
 ///|
-pub fn Union7::to1[A : Cast, B, C, D, E, F, G](
+pub fn Union7::to0[A : Cast, B, C, D, E, F, G](
   self : Union7[A, B, C, D, E, F, G]
 ) -> A? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union7::to2[A, B : Cast, C, D, E, F, G](
+pub fn Union7::to1[A, B : Cast, C, D, E, F, G](
   self : Union7[A, B, C, D, E, F, G]
 ) -> B? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union7::to3[A, B, C : Cast, D, E, F, G](
+pub fn Union7::to2[A, B, C : Cast, D, E, F, G](
   self : Union7[A, B, C, D, E, F, G]
 ) -> C? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union7::to4[A, B, C, D : Cast, E, F, G](
+pub fn Union7::to3[A, B, C, D : Cast, E, F, G](
   self : Union7[A, B, C, D, E, F, G]
 ) -> D? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union7::to5[A, B, C, D, E : Cast, F, G](
+pub fn Union7::to4[A, B, C, D, E : Cast, F, G](
   self : Union7[A, B, C, D, E, F, G]
 ) -> E? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union7::to6[A, B, C, D, E, F : Cast, G](
+pub fn Union7::to5[A, B, C, D, E, F : Cast, G](
   self : Union7[A, B, C, D, E, F, G]
 ) -> F? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union7::to7[A, B, C, D, E, F, G : Cast](
+pub fn Union7::to6[A, B, C, D, E, F, G : Cast](
   self : Union7[A, B, C, D, E, F, G]
 ) -> G? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union7::from1[A : Cast, B, C, D, E, F, G](
+pub fn Union7::from0[A : Cast, B, C, D, E, F, G](
   value : A
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union7::from2[A, B : Cast, C, D, E, F, G](
+pub fn Union7::from1[A, B : Cast, C, D, E, F, G](
   value : B
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union7::from3[A, B, C : Cast, D, E, F, G](
+pub fn Union7::from2[A, B, C : Cast, D, E, F, G](
   value : C
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union7::from4[A, B, C, D : Cast, E, F, G](
+pub fn Union7::from3[A, B, C, D : Cast, E, F, G](
   value : D
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union7::from5[A, B, C, D, E : Cast, F, G](
+pub fn Union7::from4[A, B, C, D, E : Cast, F, G](
   value : E
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union7::from6[A, B, C, D, E, F : Cast, G](
+pub fn Union7::from5[A, B, C, D, E, F : Cast, G](
   value : F
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union7::from7[A, B, C, D, E, F, G : Cast](
+pub fn Union7::from6[A, B, C, D, E, F, G : Cast](
   value : G
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
@@ -342,112 +342,112 @@ pub fn Union7::from7[A, B, C, D, E, F, G : Cast](
 type Union8[_, _, _, _, _, _, _, _]
 
 ///|
-pub fn Union8::to1[A : Cast, B, C, D, E, F, G, H](
+pub fn Union8::to0[A : Cast, B, C, D, E, F, G, H](
   self : Union8[A, B, C, D, E, F, G, H]
 ) -> A? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union8::to2[A, B : Cast, C, D, E, F, G, H](
+pub fn Union8::to1[A, B : Cast, C, D, E, F, G, H](
   self : Union8[A, B, C, D, E, F, G, H]
 ) -> B? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union8::to3[A, B, C : Cast, D, E, F, G, H](
+pub fn Union8::to2[A, B, C : Cast, D, E, F, G, H](
   self : Union8[A, B, C, D, E, F, G, H]
 ) -> C? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union8::to4[A, B, C, D : Cast, E, F, G, H](
+pub fn Union8::to3[A, B, C, D : Cast, E, F, G, H](
   self : Union8[A, B, C, D, E, F, G, H]
 ) -> D? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union8::to5[A, B, C, D, E : Cast, F, G, H](
+pub fn Union8::to4[A, B, C, D, E : Cast, F, G, H](
   self : Union8[A, B, C, D, E, F, G, H]
 ) -> E? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union8::to6[A, B, C, D, E, F : Cast, G, H](
+pub fn Union8::to5[A, B, C, D, E, F : Cast, G, H](
   self : Union8[A, B, C, D, E, F, G, H]
 ) -> F? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union8::to7[A, B, C, D, E, F, G : Cast, H](
+pub fn Union8::to6[A, B, C, D, E, F, G : Cast, H](
   self : Union8[A, B, C, D, E, F, G, H]
 ) -> G? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union8::to8[A, B, C, D, E, F, G, H : Cast](
+pub fn Union8::to7[A, B, C, D, E, F, G, H : Cast](
   self : Union8[A, B, C, D, E, F, G, H]
 ) -> H? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
-pub fn Union8::from1[A : Cast, B, C, D, E, F, G, H](
+pub fn Union8::from0[A : Cast, B, C, D, E, F, G, H](
   value : A
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union8::from2[A, B : Cast, C, D, E, F, G, H](
+pub fn Union8::from1[A, B : Cast, C, D, E, F, G, H](
   value : B
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union8::from3[A, B, C : Cast, D, E, F, G, H](
+pub fn Union8::from2[A, B, C : Cast, D, E, F, G, H](
   value : C
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union8::from4[A, B, C, D : Cast, E, F, G, H](
+pub fn Union8::from3[A, B, C, D : Cast, E, F, G, H](
   value : D
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union8::from5[A, B, C, D, E : Cast, F, G, H](
+pub fn Union8::from4[A, B, C, D, E : Cast, F, G, H](
   value : E
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union8::from6[A, B, C, D, E, F : Cast, G, H](
+pub fn Union8::from5[A, B, C, D, E, F : Cast, G, H](
   value : F
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union8::from7[A, B, C, D, E, F, G : Cast, H](
+pub fn Union8::from6[A, B, C, D, E, F, G : Cast, H](
   value : G
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
-pub fn Union8::from8[A, B, C, D, E, F, G, H : Cast](
+pub fn Union8::from7[A, B, C, D, E, F, G, H : Cast](
   value : H
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()


### PR DESCRIPTION
make the `fromN` and `toN` functions zero-based to align with tuple selection