### PR TITLE
add optional type

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "rami3l/js-ffi",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "readme": "README.md",
   "repository": "",
   "license": "Apache-2.0",

--- a/src/js/js.mbti
+++ b/src/js/js.mbti
@@ -51,6 +51,15 @@ impl Object {
   op_set[K, V](Self, K, V) -> Unit
 }
 
+type Optional[_]
+impl Optional {
+  from_option[T](T?) -> Self[T]
+  get_exn[T](Self[T]) -> T
+  is_undefined[T](Self[T]) -> Bool
+  to_option[T](Self[T]) -> T?
+  undefined[T]() -> Self[T]
+}
+
 pub type Promise[_]
 
 type Symbol

--- a/src/js/optional.mbt
+++ b/src/js/optional.mbt
@@ -1,0 +1,32 @@
+///|
+type Optional[_]
+
+///|
+pub fn Optional::is_undefined[T](self : Optional[T]) -> Bool {
+  self |> Value::cast_from |> Value::is_undefined
+}
+
+///|
+pub fn Optional::get_exn[T](self : Optional[T]) -> T = "%identity"
+
+///|
+pub fn Optional::to_option[T](self : Optional[T]) -> T? {
+  if Value::cast_from(self).is_undefined() {
+    None
+  } else {
+    Some(self.get_exn())
+  }
+}
+
+///|
+pub fn Optional::undefined[T]() -> Optional[T] {
+  Value::undefined().cast()
+}
+
+///|
+pub fn Optional::from_option[T](value : T?) -> Optional[T] {
+  match value {
+    Some(v) => Value::cast_from(v).cast()
+    None => Optional::undefined()
+  }
+}


### PR DESCRIPTION
`Optional[A]` is a type that represents a JavaScript value which can be of type `A` or `undefined`. It's useful for JS FFI bindings when the JavaScript function requires an optional argument:

```mbt
extern "js" fn Render2DContext::fill_text(content : String, width : Optional[Int]) = "..."
```