### PR TITLE
fix(async)!: remove type parameter from `Promise`

### DIFF
--- a/src/js/async.mbt
+++ b/src/js/async.mbt
@@ -7,10 +7,10 @@ pub async fn suspend[T, E : Error](
 pub fn async_run(f : async () -> Unit) -> Unit = "%async.run"
 
 ///|
-pub type Promise[_]
+pub type Promise
 
 ///|
-pub typealias AsyncOp = () -> Promise[Value]
+pub typealias AsyncOp = () -> Promise
 
 ///|
 extern "js" fn async_wrap_ffi(
@@ -25,18 +25,18 @@ pub async fn async_wrap(op : AsyncOp) -> Value! {
 }
 
 ///|
-extern "js" fn async_unwrap_ffi(op : async () -> Value!) -> Promise[Value] =
+extern "js" fn async_unwrap_ffi(op : async () -> Value!) -> Promise =
   #| (op) => new Promise((k, ke) => op(k, ke))
 
 ///|
-pub fn async_unwrap[T](op : async () -> T!) -> Promise[Value] {
+pub fn async_unwrap[T](op : async () -> T!) -> Promise {
   async_unwrap_ffi(fn() { Value::cast_from(op!!()) })
 }
 
 ///|
 /// # Note
-/// The return type is guaranteed to be a `Promise[Array[Value]]`, but we omit that detail for simplicity.
-extern "js" fn Promise::all_ffi(ops : Array[Promise[Value]]) -> Promise[Value] = "(ops) => Promise.all(ops)"
+/// The return type is guaranteed to be a `Promise` of an `Array`, but we omit that detail for simplicity.
+extern "js" fn Promise::all_ffi(ops : Array[Promise]) -> Promise = "(ops) => Promise.all(ops)"
 
 ///|
 async fn async_all_raw!(ops : Array[async () -> Value!]) -> Array[Value] {

--- a/src/js/js.mbti
+++ b/src/js/js.mbti
@@ -9,9 +9,9 @@ fn async_run(() -> Unit) -> Unit
 
 fn async_test(() -> Unit!) -> Unit
 
-fn async_unwrap[T](() -> T!) -> Promise[Value]
+fn async_unwrap[T](() -> T!) -> Promise
 
-fn async_wrap(() -> Promise[Value]) -> Value!
+fn async_wrap(() -> Promise) -> Value!
 
 let globalThis : Value
 
@@ -60,7 +60,7 @@ impl Optional {
   undefined[T]() -> Self[T]
 }
 
-pub type Promise[_]
+pub type Promise
 
 type Symbol
 impl Symbol {
@@ -204,7 +204,7 @@ impl Show for Value
 impl @moonbitlang/core/json.FromJson for Value
 
 // Type aliases
-pub typealias AsyncOp = () -> Promise[Value]
+pub typealias AsyncOp = () -> Promise
 
 // Traits
 pub(open) trait Cast {


### PR DESCRIPTION
This prevents one from accidentally obtaining a `Promise[Promise[T]]` which has no meaning in JavaScript.

Related to: https://forum.rescript-lang.org/t/help-about-promises-flattening/4399

cc @peter-jerry-ye 