### PR TITLE
Fix all MoonBit warnings

### DIFF
--- a/src/js/async.mbt
+++ b/src/js/async.mbt
@@ -78,7 +78,7 @@ async fn async_all_raw(
 
 ///|
 pub fn async_test(op : async () -> Unit raise) -> Unit {
-  async_run(async fn() {
+  async_run(async fn() noraise {
     op() catch {
       e => {
         println("ERROR in `async_test`: \{e}")

--- a/src/js/async.mbt
+++ b/src/js/async.mbt
@@ -1,10 +1,10 @@
 ///|
 pub async fn[T, E : Error] suspend(
-  f : ((T) -> Unit, (E) -> Unit) -> Unit
+  f : ((T) -> Unit, (E) -> Unit) -> Unit,
 ) -> T raise E = "%async.suspend"
 
 ///|
-pub fn async_run(f : async () -> Unit) -> Unit = "%async.run"
+pub fn async_run(f : async () -> Unit noraise) -> Unit = "%async.run"
 
 ///|
 /// # Safety
@@ -21,7 +21,7 @@ pub type Promise
 extern "js" fn Promise::wait_ffi(
   self : Promise,
   on_ok : (Value) -> Unit,
-  on_err : (Value) -> Unit
+  on_err : (Value) -> Unit,
 ) -> Unit =
   #| (self, on_ok, on_err) => self.then((t) => on_ok(t), (e) => on_err(e))
 
@@ -71,7 +71,7 @@ pub async fn[T] async_all(ops : Array[async () -> T raise]) -> Array[T] raise {
 
 ///|
 async fn async_all_raw(
-  ops : Array[async () -> Value raise]
+  ops : Array[async () -> Value raise],
 ) -> Array[Value] raise {
   Promise::all(ops.map(Promise::unsafe_new)).wait().cast()
 }

--- a/src/js/async_test.mbt
+++ b/src/js/async_test.mbt
@@ -1,16 +1,16 @@
 ///|
-async fn op1() -> String? {
+async fn op1() -> String? noraise {
   Some("Hello")
 }
 
 ///|
-async fn op2() -> String? {
+async fn op2() -> String? noraise {
   guard op1() is Some(prefix)
   Some(prefix + ", World")
 }
 
 ///|
-async fn op3() -> String? {
+async fn op3() -> String? noraise {
   None
 }
 

--- a/src/js/error.mbt
+++ b/src/js/error.mbt
@@ -26,14 +26,14 @@ pub impl Show for Error_ with output(self, logger) {
 extern "js" fn Error_::wrap_ffi(
   op : () -> Value,
   on_ok : (Value) -> Unit,
-  on_error : (Value) -> Unit
+  on_error : (Value) -> Unit,
 ) -> Unit =
   #| (op, on_ok, on_error) => { try { on_ok(op()); } catch (e) { on_error(e); } }
 
 ///|
 pub fn[T] Error_::wrap(
   op : () -> Value,
-  map_ok~ : (Value) -> T = Value::cast
+  map_ok~ : (Value) -> T = Value::cast,
 ) -> T raise Error_ {
   let mut res : Result[Value, Error_] = Ok(Value::undefined())
   Error_::wrap_ffi(op, fn(v) { res = Ok(v) }, fn(e) { res = Err(Error_(e)) })

--- a/src/js/js.mbti
+++ b/src/js/js.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "rami3l/js-ffi/js"
 
 import(
@@ -5,13 +6,13 @@ import(
 )
 
 // Values
-async fn[T] async_all(Array[() -> T raise]) -> Array[T] raise
+async fn[T] async_all(Array[async () -> T raise]) -> Array[T] raise
 
 let async_iterator : Symbol
 
-fn async_run(() -> Unit) -> Unit
+fn async_run(async () -> Unit) -> Unit
 
-fn async_test(() -> Unit raise) -> Unit
+fn async_test(async () -> Unit raise) -> Unit
 
 let globalThis : Value
 
@@ -19,7 +20,7 @@ let iterator : Symbol
 
 fn require(String, keys~ : Array[String] = ..) -> Value
 
-fn[T, E : Error] spawn_detach(() -> T raise E) -> Unit
+fn[T, E : Error] spawn_detach(async () -> T raise E) -> Unit
 
 async fn[T, E : Error] suspend(((T) -> Unit, (E) -> Unit) -> Unit) -> T raise E
 
@@ -64,7 +65,7 @@ fn[T] Optional::unwrap(Self[T]) -> T
 #external
 pub type Promise
 fn Promise::all(Array[Self]) -> Self
-fn[T] Promise::unsafe_new(() -> T raise) -> Self
+fn[T] Promise::unsafe_new(async () -> T raise) -> Self
 async fn Promise::wait(Self) -> Value raise
 
 type Symbol

--- a/src/js/null.mbt
+++ b/src/js/null.mbt
@@ -32,5 +32,5 @@ pub fn[T] Nullable::null() -> Nullable[T] {
 
 ///|
 pub fn[T] Nullable::from_option(value : T?) -> Nullable[T] {
-  value.map(Value::cast_from).or_else(Value::null).cast()
+  value.map(Value::cast_from).unwrap_or_else(Value::null).cast()
 }

--- a/src/js/union.mbt
+++ b/src/js/union.mbt
@@ -160,84 +160,84 @@ type Union6[_, _, _, _, _, _]
 
 ///|
 pub fn[A : Cast, B, C, D, E, F] Union6::to0(
-  self : Union6[A, B, C, D, E, F]
+  self : Union6[A, B, C, D, E, F],
 ) -> A? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B : Cast, C, D, E, F] Union6::to1(
-  self : Union6[A, B, C, D, E, F]
+  self : Union6[A, B, C, D, E, F],
 ) -> B? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C : Cast, D, E, F] Union6::to2(
-  self : Union6[A, B, C, D, E, F]
+  self : Union6[A, B, C, D, E, F],
 ) -> C? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C, D : Cast, E, F] Union6::to3(
-  self : Union6[A, B, C, D, E, F]
+  self : Union6[A, B, C, D, E, F],
 ) -> D? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C, D, E : Cast, F] Union6::to4(
-  self : Union6[A, B, C, D, E, F]
+  self : Union6[A, B, C, D, E, F],
 ) -> E? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C, D, E, F : Cast] Union6::to5(
-  self : Union6[A, B, C, D, E, F]
+  self : Union6[A, B, C, D, E, F],
 ) -> F? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A : Cast, B, C, D, E, F] Union6::from0(
-  value : A
+  value : A,
 ) -> Union6[A, B, C, D, E, F] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B : Cast, C, D, E, F] Union6::from1(
-  value : B
+  value : B,
 ) -> Union6[A, B, C, D, E, F] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C : Cast, D, E, F] Union6::from2(
-  value : C
+  value : C,
 ) -> Union6[A, B, C, D, E, F] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C, D : Cast, E, F] Union6::from3(
-  value : D
+  value : D,
 ) -> Union6[A, B, C, D, E, F] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C, D, E : Cast, F] Union6::from4(
-  value : E
+  value : E,
 ) -> Union6[A, B, C, D, E, F] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C, D, E, F : Cast] Union6::from5(
-  value : F
+  value : F,
 ) -> Union6[A, B, C, D, E, F] {
   Cast::from(value).cast()
 }
@@ -248,98 +248,98 @@ type Union7[_, _, _, _, _, _, _]
 
 ///|
 pub fn[A : Cast, B, C, D, E, F, G] Union7::to0(
-  self : Union7[A, B, C, D, E, F, G]
+  self : Union7[A, B, C, D, E, F, G],
 ) -> A? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B : Cast, C, D, E, F, G] Union7::to1(
-  self : Union7[A, B, C, D, E, F, G]
+  self : Union7[A, B, C, D, E, F, G],
 ) -> B? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C : Cast, D, E, F, G] Union7::to2(
-  self : Union7[A, B, C, D, E, F, G]
+  self : Union7[A, B, C, D, E, F, G],
 ) -> C? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C, D : Cast, E, F, G] Union7::to3(
-  self : Union7[A, B, C, D, E, F, G]
+  self : Union7[A, B, C, D, E, F, G],
 ) -> D? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C, D, E : Cast, F, G] Union7::to4(
-  self : Union7[A, B, C, D, E, F, G]
+  self : Union7[A, B, C, D, E, F, G],
 ) -> E? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C, D, E, F : Cast, G] Union7::to5(
-  self : Union7[A, B, C, D, E, F, G]
+  self : Union7[A, B, C, D, E, F, G],
 ) -> F? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C, D, E, F, G : Cast] Union7::to6(
-  self : Union7[A, B, C, D, E, F, G]
+  self : Union7[A, B, C, D, E, F, G],
 ) -> G? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A : Cast, B, C, D, E, F, G] Union7::from0(
-  value : A
+  value : A,
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B : Cast, C, D, E, F, G] Union7::from1(
-  value : B
+  value : B,
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C : Cast, D, E, F, G] Union7::from2(
-  value : C
+  value : C,
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C, D : Cast, E, F, G] Union7::from3(
-  value : D
+  value : D,
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C, D, E : Cast, F, G] Union7::from4(
-  value : E
+  value : E,
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C, D, E, F : Cast, G] Union7::from5(
-  value : F
+  value : F,
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C, D, E, F, G : Cast] Union7::from6(
-  value : G
+  value : G,
 ) -> Union7[A, B, C, D, E, F, G] {
   Cast::from(value).cast()
 }
@@ -350,112 +350,112 @@ type Union8[_, _, _, _, _, _, _, _]
 
 ///|
 pub fn[A : Cast, B, C, D, E, F, G, H] Union8::to0(
-  self : Union8[A, B, C, D, E, F, G, H]
+  self : Union8[A, B, C, D, E, F, G, H],
 ) -> A? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B : Cast, C, D, E, F, G, H] Union8::to1(
-  self : Union8[A, B, C, D, E, F, G, H]
+  self : Union8[A, B, C, D, E, F, G, H],
 ) -> B? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C : Cast, D, E, F, G, H] Union8::to2(
-  self : Union8[A, B, C, D, E, F, G, H]
+  self : Union8[A, B, C, D, E, F, G, H],
 ) -> C? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C, D : Cast, E, F, G, H] Union8::to3(
-  self : Union8[A, B, C, D, E, F, G, H]
+  self : Union8[A, B, C, D, E, F, G, H],
 ) -> D? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C, D, E : Cast, F, G, H] Union8::to4(
-  self : Union8[A, B, C, D, E, F, G, H]
+  self : Union8[A, B, C, D, E, F, G, H],
 ) -> E? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C, D, E, F : Cast, G, H] Union8::to5(
-  self : Union8[A, B, C, D, E, F, G, H]
+  self : Union8[A, B, C, D, E, F, G, H],
 ) -> F? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C, D, E, F, G : Cast, H] Union8::to6(
-  self : Union8[A, B, C, D, E, F, G, H]
+  self : Union8[A, B, C, D, E, F, G, H],
 ) -> G? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A, B, C, D, E, F, G, H : Cast] Union8::to7(
-  self : Union8[A, B, C, D, E, F, G, H]
+  self : Union8[A, B, C, D, E, F, G, H],
 ) -> H? {
   Cast::into(Value::cast_from(self))
 }
 
 ///|
 pub fn[A : Cast, B, C, D, E, F, G, H] Union8::from0(
-  value : A
+  value : A,
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B : Cast, C, D, E, F, G, H] Union8::from1(
-  value : B
+  value : B,
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C : Cast, D, E, F, G, H] Union8::from2(
-  value : C
+  value : C,
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C, D : Cast, E, F, G, H] Union8::from3(
-  value : D
+  value : D,
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C, D, E : Cast, F, G, H] Union8::from4(
-  value : E
+  value : E,
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C, D, E, F : Cast, G, H] Union8::from5(
-  value : F
+  value : F,
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C, D, E, F, G : Cast, H] Union8::from6(
-  value : G
+  value : G,
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }
 
 ///|
 pub fn[A, B, C, D, E, F, G, H : Cast] Union8::from7(
-  value : H
+  value : H,
 ) -> Union8[A, B, C, D, E, F, G, H] {
   Cast::from(value).cast()
 }

--- a/src/js/value.mbt
+++ b/src/js/value.mbt
@@ -60,7 +60,7 @@ pub fn[Arg, Result] Value::apply(self : Value, args : Array[Arg]) -> Result {
 pub fn[Arg, Result] Value::apply_with_string(
   self : Value,
   key : String,
-  args : Array[Arg]
+  args : Array[Arg],
 ) -> Result {
   self.apply_ffi(Value::cast_from(key), Value::cast_from(args)).cast()
 }
@@ -70,7 +70,7 @@ pub fn[Arg, Result] Value::apply_with_string(
 pub fn[Arg, Result] Value::apply_with_symbol(
   self : Value,
   key : Symbol,
-  args : Array[Arg]
+  args : Array[Arg],
 ) -> Result {
   self.apply_ffi(Value::cast_from(key), Value::cast_from(args)).cast()
 }
@@ -80,7 +80,7 @@ pub fn[Arg, Result] Value::apply_with_symbol(
 pub fn[Arg, Result] Value::apply_with_index(
   self : Value,
   index : Int,
-  args : Array[Arg]
+  args : Array[Arg],
 ) -> Result {
   self.apply_ffi(Value::cast_from(index), Value::cast_from(args)).cast()
 }
@@ -96,7 +96,7 @@ pub fn[Arg, Result] Value::new(self : Value, args : Array[Arg]) -> Result {
 pub fn[Arg, Result] Value::new_with_string(
   self : Value,
   key : String,
-  args : Array[Arg]
+  args : Array[Arg],
 ) -> Result {
   self.new_ffi(Value::cast_from(key), Value::cast_from(args)).cast()
 }
@@ -106,7 +106,7 @@ pub fn[Arg, Result] Value::new_with_string(
 pub fn[Arg, Result] Value::new_with_symbol(
   self : Value,
   key : Symbol,
-  args : Array[Arg]
+  args : Array[Arg],
 ) -> Result {
   self.new_ffi(Value::cast_from(key), Value::cast_from(args)).cast()
 }
@@ -116,7 +116,7 @@ pub fn[Arg, Result] Value::new_with_symbol(
 pub fn[Arg, Result] Value::new_with_index(
   self : Value,
   index : Int,
-  args : Array[Arg]
+  args : Array[Arg],
 ) -> Result {
   self.new_ffi(Value::cast_from(index), Value::cast_from(args)).cast()
 }

--- a/src/js/value.mbt
+++ b/src/js/value.mbt
@@ -130,7 +130,7 @@ pub fn Value::from_json(json : Json) -> Value raise {
 pub impl @json.FromJson for Value with from_json(json : Json, path) {
   match json {
     String(s) => Value::cast_from(s)
-    Number(n) => Value::cast_from(n)
+    Number(n, ..) => Value::cast_from(n)
     False => Value::cast_from(false)
     True => Value::cast_from(true)
     Null => Value::null()

--- a/src/js/value_test.mbt
+++ b/src/js/value_test.mbt
@@ -66,9 +66,9 @@ let json_val : @js.Value = (try? @js.Value::from_json_string(json_str_pretty)).u
 test "Value::to_json_string" {
   inspect(
     json_val.to_json_string(),
-    content=
+    content=(
       #|{"_id":"67a6c712bc218526d5e1b516","index":0,"guid":"74e69a18-680a-4a74-a401-e386c30d0a35","isActive":false,"balance":"$3,140.03","picture":"http://placehold.it/32x32","age":33,"eyeColor":"blue","name":"Burt Dominguez","gender":"male","company":"GEEKWAGON","email":"burtdominguez@geekwagon.com","phone":"+1 (913) 583-3488","address":"379 Essex Street, Fresno, Minnesota, 5304","about":"Proident velit ullamco cillum occaecat irure eu proident commodo consectetur est ut elit consectetur.","registered":"2020-12-06T01:54:20 -08:00","latitude":71.680916,"longitude":-88.552886,"tags":["aute","occaecat","qui","esse","commodo","sint","proident"],"friends":[{"id":0,"name":"Gilliam Mcgowan"},{"id":1,"name":"Bryan Stanton"},{"id":2,"name":"Jenifer Elliott"}],"greeting":"Hello, Burt Dominguez! You have 4 unread messages.","favoriteFruit":"apple"}
-    ,
+    ),
   )
 }
 


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This PR addresses all MoonBit warnings in the project:

- Add missing error annotations to async functions
- Replace deprecated `or_else()` with `unwrap_or_else()`
- Fix constructor pattern completeness for `Number(n, ..)`

All changes maintain backward compatibility and improve code quality
by following current MoonBit best practices.