### PR TITLE
Add `Iterable`, `Iterator`, and some `Value` utility methods

### DIFF
--- a/src/js/iteration.mbt
+++ b/src/js/iteration.mbt
@@ -1,0 +1,123 @@
+///|
+#external
+pub type Iterator[T]
+
+///|
+#warnings("-unused_field")
+priv struct IteratorResult {
+  value : Value
+  done : Bool
+}
+
+///|
+fn[T] IteratorResult::cast(self : IteratorResult) -> T? {
+  if self.done {
+    None
+  } else {
+    Some(self.value.cast())
+  }
+}
+
+///|
+pub fn[T] Iterator::from_iter(iter : Iter[T]) -> Iterator[T] {
+  Object::new()
+  ..op_set("next", () => match iter.next() {
+    Some(value) => { value: Value::cast_from(value), done: false }
+    None => { value: Value::undefined(), done: true }
+  })
+  .to_value()
+  .cast()
+}
+
+///|
+pub fn[T] Iterator::iter(self : Iterator[T]) -> Iter[T] {
+  Iter::new(() => self.next())
+}
+
+///|
+pub fn[T] Iterator::next(self : Iterator[T]) -> T? {
+  let result : IteratorResult = Value::cast_from(self).apply0_with_string(
+    "next",
+  )
+  result.cast()
+}
+
+///|
+pub fn[T, Next] Iterator::next_with(self : Iterator[T], value : Next) -> T? {
+  let result : IteratorResult = Value::cast_from(self).apply_with_string(
+    "next",
+    [Value::cast_from(value)],
+  )
+  result.cast()
+}
+
+///|
+pub fn[T] Iterator::can_stop(self : Iterator[T]) -> Bool {
+  Value::cast_from(self).has("return")
+}
+
+///|
+pub fn[T] Iterator::stop(self : Iterator[T]) -> Unit {
+  Value::cast_from(self).apply0_with_string("return")
+}
+
+///|
+pub fn[T] Iterator::stop_with(self : Iterator[T], value : T) -> T? {
+  let result : IteratorResult = Value::cast_from(self).apply_with_string(
+    "return",
+    [Value::cast_from(value)],
+  )
+  result.cast()
+}
+
+///|
+pub fn[T] Iterator::can_throw(self : Iterator[T]) -> Bool {
+  Value::cast_from(self).has("throw")
+}
+
+///|
+pub fn[T] Iterator::throw_(self : Iterator[T]) -> T? {
+  let result : IteratorResult = Value::cast_from(self).apply0_with_string(
+    "throw",
+  )
+  result.cast()
+}
+
+///|
+pub fn[T, Err] Iterator::throw_with(self : Iterator[T], value : Err) -> T? {
+  let result : IteratorResult = Value::cast_from(self).apply_with_string(
+    "throw",
+    [Value::cast_from(value)],
+  )
+  result.cast()
+}
+
+///|
+#external
+pub type Iterable[T]
+
+///|
+/// Test if a given object might be iterable.
+/// This function only checks for the presence of the `Symbol.iterator` property and that it is a function.
+/// The actual iteration protocol is not verified.
+pub fn Iterable::might_be_iterable(obj : Value) -> Bool {
+  obj.has_symbol(iterator) &&
+  (obj.get_with_symbol(iterator) : Value).is_function()
+}
+
+///|
+pub fn[T] Iterable::iterator(self : Iterable[T]) -> Iterator[T] {
+  Value::cast_from(self).apply0_with_symbol(iterator)
+}
+
+///|
+pub fn[T] Iterable::iter(self : Iterable[T]) -> Iter[T] {
+  self.iterator().iter()
+}
+
+pub fn[T] Iterable::from_iter(iter : Iter[T]) -> Iterable[T] {
+  Object::new()
+  ..op_set(iterator, () => Iterator::from_iter(iter))
+  .to_value()
+  .cast()
+}

--- a/src/js/iteration_test.mbt
+++ b/src/js/iteration_test.mbt
@@ -1,0 +1,131 @@
+///|
+extern "js" fn generator() -> Iterable[String] =
+  #|function*() {
+  #|  try {
+  #|    yield "a";
+  #|    yield "b";
+  #|    if (yield "c") {
+  #|      yield "d";
+  #|    }
+  #|  } catch (e) {
+  #|    yield "caught " + e;
+  #|  }
+  #|}
+
+///|
+test "Iterable::might_be_iterable" {
+  let it = generator()
+  inspect(Iterable::might_be_iterable(Value::cast_from(it)), content="true")
+  inspect(Iterable::might_be_iterable(Value::cast_from(42)), content="false")
+}
+
+///|
+test "Iterable::iter" {
+  let it = generator()
+  let iter = it.iter()
+  inspect(
+    iter.collect(),
+    content=(
+      #|["a", "b", "c"]
+    ),
+  )
+}
+
+///|
+test "Iterator::next" {
+  let it = generator()
+  let iter = it.iterator()
+  inspect(
+    iter.next(),
+    content=(
+      #|Some("a")
+    ),
+  )
+  inspect(
+    iter.next(),
+    content=(
+      #|Some("b")
+    ),
+  )
+  inspect(
+    iter.next(),
+    content=(
+      #|Some("c")
+    ),
+  )
+  inspect(iter.next() is None, content="true")
+}
+
+///|
+test "Iterator::next with conditional yield" {
+  let it = generator()
+  let iter = it.iterator()
+  for _ in 0..<3 {
+    iter.next() |> ignore
+  }
+  inspect(
+    iter.next_with(true),
+    content=(
+      #|Some("d")
+    ),
+  )
+}
+
+///|
+test "Iterator::can_stop and Iterator::stop" {
+  let it = generator()
+  let iter = it.iterator()
+  inspect(iter.can_stop(), content="true")
+  iter.stop()
+  inspect(iter.next() is None, content="true")
+}
+
+///|
+test "Iterator::stop_with" {
+  let it = generator()
+  let iter = it.iterator()
+  inspect(iter.can_stop(), content="true")
+  inspect(iter.stop_with("stopped"), content="None")
+}
+
+///|
+test "Iterator::can_throw and Iterator::throw_" {
+  let it = generator()
+  let iter = it.iterator()
+  inspect(iter.can_throw(), content="true")
+  iter.next() |> ignore
+  inspect(
+    iter.throw_(),
+    content=(
+      #|Some("caught undefined")
+    ),
+  )
+  inspect(iter.next() is None, content="true")
+}
+
+///|
+test "Iterator::throw_with" {
+  let it = generator()
+  let iter = it.iterator()
+  inspect(iter.can_throw(), content="true")
+  iter.next() |> ignore
+  inspect(
+    iter.throw_with("error"),
+    content=(
+      #|Some("caught error")
+    ),
+  )
+  inspect(iter.next() is None, content="true")
+}
+
+test "Iterator::from_iter" {
+  let arr = [1, 1, 4]
+  let it = Iterator::from_iter(arr.iter())
+  inspect(it.iter().collect(), content="[1, 1, 4]")
+}
+
+test "Iterable::from_iter" {
+  let arr = [5, 1, 4]
+  let iterable = Iterable::from_iter(arr.iter())
+  inspect(iterable.iter().collect(), content="[5, 1, 4]")
+}

--- a/src/js/value.mbt
+++ b/src/js/value.mbt
@@ -295,9 +295,9 @@ pub extern "js" fn Value::extends(
 ///|
 /// `key in self`
 pub extern "js" fn Value::has(self : Value, key : String) -> Bool =
-  #| (obj, key) => key in obj
+  #| (obj, key) => Object.is(typeof obj, "object") && key in obj
 
 ///|
 /// `key in self`
 pub extern "js" fn Value::has_symbol(self : Value, key : Symbol) -> Bool =
-  #| (obj, key) => key in obj
+  #| (obj, key) => Object.is(typeof obj, "object") && key in obj

--- a/src/js/value.mbt
+++ b/src/js/value.mbt
@@ -226,6 +226,10 @@ pub extern "js" fn Value::is_symbol(self : Value) -> Bool =
   #| (n) => Object.is(typeof n, "symbol")
 
 ///|
+pub extern "js" fn Value::is_function(self : Value) -> Bool =
+  #| (n) => Object.is(typeof n, "function")
+
+///|
 extern "js" fn get_globalThis() -> Value =
   #| () => globalThis
 

--- a/src/js/value.mbt
+++ b/src/js/value.mbt
@@ -56,6 +56,12 @@ pub fn[Arg, Result] Value::apply(self : Value, args : Array[Arg]) -> Result {
 }
 
 ///|
+/// `self()`
+pub fn[Result] Value::apply0(self : Value) -> Result {
+  self.apply0_self_ffi().cast()
+}
+
+///|
 /// `self[key](...args)`
 pub fn[Arg, Result] Value::apply_with_string(
   self : Value,
@@ -63,6 +69,24 @@ pub fn[Arg, Result] Value::apply_with_string(
   args : Array[Arg],
 ) -> Result {
   self.apply_ffi(Value::cast_from(key), Value::cast_from(args)).cast()
+}
+
+///|
+/// `self[key]()`
+pub fn[Result] Value::apply0_with_string(self : Value, key : String) -> Result {
+  self.apply0_ffi(Value::cast_from(key)).cast()
+}
+
+///|
+/// `self[key]()`
+pub fn[Result] Value::apply0_with_symbol(self : Value, key : Symbol) -> Result {
+  self.apply0_ffi(Value::cast_from(key)).cast()
+}
+
+///|
+/// `self[index]()`
+pub fn[Result] Value::apply0_with_index(self : Value, index : Int) -> Result {
+  self.apply0_ffi(Value::cast_from(index)).cast()
 }
 
 ///|
@@ -222,8 +246,16 @@ extern "js" fn Value::apply_ffi(
   #| (self, key, args) => self[key](...args)
 
 ///|
+extern "js" fn Value::apply0_ffi(self : Value, key : Value) -> Value =
+  #| (self, key) => self[key]()
+
+///|
 extern "js" fn Value::apply_self_ffi(self : Value, args : Value) -> Value =
   #| (self, args) => self(...args)
+
+///|
+extern "js" fn Value::apply0_self_ffi(self : Value) -> Value =
+  #| (self) => self()
 
 ///|
 extern "js" fn Value::new_ffi(self : Value, key : Value, args : Value) -> Value =
@@ -255,3 +287,13 @@ pub extern "js" fn Value::extends(
   #|    }
   #|  }
   #|}
+
+///|
+/// `key in self`
+pub extern "js" fn Value::has(self : Value, key : String) -> Bool =
+  #| (obj, key) => key in obj
+
+///|
+/// `key in self`
+pub extern "js" fn Value::has_symbol(self : Value, key : Symbol) -> Bool =
+  #| (obj, key) => key in obj


### PR DESCRIPTION
The newly-introduced `Iterable` and `Iterator` types provide support for JavaScript's [Iteration Protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).

The `Value::has` methods provide a concise way to test the precense of certain keys.

The `Value::apply0` methods call the given methods with no arguments. `self.apply([])` is semantically equivalent to `self.apply0()`, but emits an unresolved type variable warning, as there's no explicit type application in MoonBit. A workaround is to write `self.apply(([] : Array[T]))`, where `T` can be any type. However, doing so is cumbersome.
